### PR TITLE
Add parentheses around computed define expressions

### DIFF
--- a/ulisp-esp.ino
+++ b/ulisp-esp.ino
@@ -56,13 +56,13 @@ Adafruit_SSD1306 tft(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire);
 #define BUFFERSIZE 34  // Number of bits+2
 
 #if defined(ESP8266)
-  #define WORKSPACESIZE 4000-SDSIZE       /* Cells (8*bytes) */
+  #define WORKSPACESIZE (4000-SDSIZE)     /* Cells (8*bytes) */
   #define EEPROMSIZE 4096                 /* Bytes available for EEPROM */
   #define SYMBOLTABLESIZE 512             /* Bytes */
   #define SDCARD_SS_PIN 10
 
 #elif defined(ESP32)
-  #define WORKSPACESIZE 8000-SDSIZE       /* Cells (8*bytes) */
+  #define WORKSPACESIZE (8000-SDSIZE)     /* Cells (8*bytes) */
   #define EEPROMSIZE 4096                 /* Bytes available for EEPROM */
   #define SYMBOLTABLESIZE 1024            /* Bytes */
   #define analogWrite(x,y) dacWrite((x),(y))


### PR DESCRIPTION
Currently WORKSPACESIZE macro is unhygienic and causes following errors with verbose compiler flags:

```
ulisp-esp.ino: In function 'object* eval(object*, object*)':
ulisp-esp:4410:33: error: suggest parentheses around '-' inside '>>' [-Werror=parentheses]
   if (Freespace <= WORKSPACESIZE>>4) gc(form, env);
                                 ^
cc1plus: some warnings being treated as errors
```
This commit adds parentheses around WORKSPACESIZE body to remove the ambiguity.